### PR TITLE
[ADD]会員・管理者側のバリデーション、プロフィール・配送先編集にエラーメッセージ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ gem 'devise'
 gem 'kaminari','~> 1.2.1'
 gem 'bootstrap5-kaminari-views', '~> 0.0.1'
 gem "enum_help"
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.7.3)
       actionpack (= 6.1.7.3)
       activesupport (= 6.1.7.3)
@@ -337,6 +340,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.3)
+  rails-i18n
   refile!
   refile-mini_magick
   rubocop

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -13,8 +13,11 @@ class Admin::CustomersController < ApplicationController
 
   def update
     @customer=Customer.find(params[:id])
-    @customer.update(customer_params)
-    redirect_to admin_customer_path(@customer)
+    if @customer.update(customer_params)
+     redirect_to admin_customer_path(@customer)
+    else
+     render :edit
+    end
   end
 
   private

--- a/app/controllers/public/information_controller.rb
+++ b/app/controllers/public/information_controller.rb
@@ -9,8 +9,12 @@ class Public::InformationController < ApplicationController
   end
 
   def update
-    current_customer.update(customer_params)
+    @customer=current_customer
+   if @customer.update(customer_params)
     redirect_to customers_information_path
+   else
+    render :edit
+   end
   end
 
   private

--- a/app/controllers/public/shipping_addresses_controller.rb
+++ b/app/controllers/public/shipping_addresses_controller.rb
@@ -11,16 +11,24 @@ class Public::ShippingAddressesController < ApplicationController
   end
   
   def create
-    shipping_address = ShippingAddress.new(shipping_address_params)
-    shipping_address.customer=current_customer
-    shipping_address.save
-    redirect_to request.referer
+    @shipping_address = ShippingAddress.new(shipping_address_params)
+    @shipping_address.customer=current_customer
+   if @shipping_address.save
+     redirect_to request.referer
+   else
+     @customer = current_customer
+     @shipping_addresses = @customer.shipping_addresses.all
+     render :index
+   end
   end
   
   def update
-    shipping_address = ShippingAddress.find(params[:id])
-    shipping_address.update(shipping_address_params)
-    redirect_to shipping_addresses_path
+    @shipping_address = ShippingAddress.find(params[:id])
+     if @shipping_address.update(shipping_address_params)
+       redirect_to shipping_addresses_path
+     else
+       render :edit
+     end
   end
   
   def destroy

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -2,6 +2,8 @@ class CartItem < ApplicationRecord
   belongs_to :item
   belongs_to :customer
   
+  validates :count,presence:true
+  
   def sum_of_price
     item.add_tax_sales_price * count
   end 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,13 +1,13 @@
 class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  validates :post_code, format: {with: /\A[0-9]{7}\z/}
+  validates :post_code, presence:true, format: {with: /\A[0-9]{7}\z/}
   validates :first_name,presence:true
   validates :last_name,presence:true
   validates :first_name_kana,presence:true
   validates :last_name_kana,presence:true
   validates :address,presence:true
-  validates :telephone_number,format: {with: /\A0\d{9,10}\z/}
+  validates :telephone_number,presence:true, format: {with: /\A0\d{9,10}\z/}
   validates :membership_status,presence:true
   validates :email,presence:true
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,9 +1,23 @@
 class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  validates :post_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/}
+  validates :first_name,presence:true
+  validates :last_name,presence:true
+  validates :first_name_kana,presence:true
+  validates :last_name_kana,presence:true
+  validates :post_code,presence:true
+  validates :address,presence:true
+  validates :telephone_number,presence:true
+  validates :membership_status,presence:true
+  validates :email,presence:true
+
+  
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
          has_many :cart_items, dependent: :destroy
          has_many :orders, dependent: :destroy
          has_many :shipping_addresses, dependent: :destroy
+        
+ 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -6,9 +6,8 @@ class Customer < ApplicationRecord
   validates :last_name,presence:true
   validates :first_name_kana,presence:true
   validates :last_name_kana,presence:true
-  validates :post_code,presence:true
   validates :address,presence:true
-  validates :telephone_number,presence:true
+  validates :telephone_number,format: {with: /\A0\d{9,10}\z/}
   validates :membership_status,presence:true
   validates :email,presence:true
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,7 +1,7 @@
 class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  validates :post_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/}
+  validates :post_code, format: {with: /\A[0-9]{7}\z/}
   validates :first_name,presence:true
   validates :last_name,presence:true
   validates :first_name_kana,presence:true

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,3 +1,4 @@
 class Genre < ApplicationRecord
   has_many :items
+  validates :name,presence:true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,9 @@ class Item < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   attachment :image
 
+  validates :name,presence:true
+  validates :introduction,presence:true
+  validates :price,presence:true
 
   #税込価格を計算するためのメソットです。
   #viewページで下記のように呼び出してもらえれば表示できます。

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,7 @@ class Order < ApplicationRecord
   has_many :order_items, dependent: :destroy
   has_many :items, through: :order_items
   
-  validates :delivery_post_code,presence:true
+  validates :delivery_post_code, format: {with: /\A[0-9]{7}\z/}
   validates :delivery_address,presence:true
   validates :delivery_address_label,presence:true
   validates :pay_option,presence:true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,11 @@ class Order < ApplicationRecord
   belongs_to :customer
   has_many :order_items, dependent: :destroy
   has_many :items, through: :order_items
+  
+  validates :delivery_post_code,presence:true
+  validates :delivery_address,presence:true
+  validates :delivery_address_label,presence:true
+  validates :pay_option,presence:true
 
   enum order_status: {
     "入金待ち":0,

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,4 +1,7 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :item
+  
+  validates :count,presence:true
+  
 end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -2,7 +2,7 @@ class ShippingAddress < ApplicationRecord
   belongs_to :customer
 
   validates :address_label,presence:true
-  validates :post_code, format: {with: /\A[0-9]{7}\z/}
+  validates :post_code, presence:true, format: {with: /\A[0-9]{7}\z/}
   validates :address,presence:true
 
 

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -2,7 +2,7 @@ class ShippingAddress < ApplicationRecord
   belongs_to :customer
 
   validates :address_label,presence:true
-  validates :post_code,presence:true
+  validates :post_code, format: {with: /\A[0-9]{7}\z/}
   validates :address,presence:true
 
 

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,6 +1,11 @@
 class ShippingAddress < ApplicationRecord
   belongs_to :customer
 
+  validates :address_label,presence:true
+  validates :post_code,presence:true
+  validates :address,presence:true
+
+
   def address_display
     '〒' + post_code + ' ' + address + ' ' + address_label
   end

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -3,13 +3,8 @@
 <div class="col-sm-12 col-md-10 col-lg-8 px-5 px-sm-0 mx-auto">
   
 <% if @customer.errors.any? %>
-<%= @customer.errors.count %>件のエラーが発生しました
-<ul>
-  <% @customer.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</ul>
-<% end %>
+<%= render 'layouts/error_messages', model: @customer %>
+<%end%>
   
   <div class=' row py-4'>
       <h4 class="bg-light"><%= "#{@customer.first_name}"+"#{@customer.last_name}さんの会員情報編集" %></h4>

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -2,6 +2,15 @@
 <div class='row pt-5'>
 <div class="col-sm-12 col-md-10 col-lg-8 px-5 px-sm-0 mx-auto">
   
+<% if @customer.errors.any? %>
+<%= @customer.errors.count %>件のエラーが発生しました
+<ul>
+  <% @customer.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+</ul>
+<% end %>
+  
   <div class=' row py-4'>
       <h4 class="bg-light"><%= "#{@customer.first_name}"+"#{@customer.last_name}さんの会員情報編集" %></h4>
   </div>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,8 @@
+<%= model.errors.count %>件のエラーが発生しました
+<ul>
+  <% model.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+</ul>
+
+  

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,4 +1,3 @@
-<%= model.errors.count %>件のエラーが発生しました
 <ul>
   <% model.errors.full_messages.each do |message| %>
     <li><%= message %></li>

--- a/app/views/public/information/edit.html.erb
+++ b/app/views/public/information/edit.html.erb
@@ -3,13 +3,8 @@
 <div class="col-sm-12 col-md-9 col-lg-9 px-5 px-sm-0 mx-auto">
   
 <% if @customer.errors.any? %>
-<%= @customer.errors.count %>件のエラーが発生しました
-<ul>
-  <% @customer.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</ul>
-<% end %>
+<%= render 'layouts/error_messages', model: @customer %>
+<%end%>
   
 <div class=' row py-4'>
     <h4 class="bg-light">会員情報編集</h4>

--- a/app/views/public/information/edit.html.erb
+++ b/app/views/public/information/edit.html.erb
@@ -2,6 +2,15 @@
 <div class='row pt-5'>
 <div class="col-sm-12 col-md-9 col-lg-9 px-5 px-sm-0 mx-auto">
   
+<% if @customer.errors.any? %>
+<%= @customer.errors.count %>件のエラーが発生しました
+<ul>
+  <% @customer.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+</ul>
+<% end %>
+  
 <div class=' row py-4'>
     <h4 class="bg-light">会員情報編集</h4>
 </div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -5,7 +5,11 @@
     <h4 class="bg-light">新規会員登録</h4>
 </div>
  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
- <%= render "public/shared/error_messages", resource: resource %>
+ 
+ <% if @customer.errors.any? %>
+ <%= render 'layouts/error_messages', model: @customer %>
+ <%end%>
+ 
  <div class="form-group">
   <table class="table table-borderless">
   <tbody>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -2,6 +2,11 @@
 <div class='row pt-5'>
 <div class="col-sm-12 col-md-9 col-lg-9 px-sm-0 mx-auto">
   
+  <div class='login-flash-message'>
+    <%= flash[:notice] %>
+    <%= flash[:alert] %>
+  </div>
+  
   <div class='py-3'>
     <h4 class="bg-light">ログイン</h4>
   </div>

--- a/app/views/public/shipping_addresses/edit.html.erb
+++ b/app/views/public/shipping_addresses/edit.html.erb
@@ -1,6 +1,15 @@
 <div class='container'>
 <div class='row pt-5'>
 <div class="col-sm-12 col-md-10 col-lg-10 px-5 px-sm-0 mx-auto">
+  
+<% if @shipping_address.errors.any? %>
+<%= @shipping_address.errors.count %>件のエラーが発生しました
+<ul>
+  <% @shipping_address.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+</ul>
+<% end %>
 
 <div class='p-4'>
     <h4 class="bg-light">配送先編集</h4>

--- a/app/views/public/shipping_addresses/edit.html.erb
+++ b/app/views/public/shipping_addresses/edit.html.erb
@@ -3,13 +3,8 @@
 <div class="col-sm-12 col-md-10 col-lg-10 px-5 px-sm-0 mx-auto">
   
 <% if @shipping_address.errors.any? %>
-<%= @shipping_address.errors.count %>件のエラーが発生しました
-<ul>
-  <% @shipping_address.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</ul>
-<% end %>
+<%= render 'layouts/error_messages', model: @shipping_address %>
+<%end%>
 
 <div class='p-4'>
     <h4 class="bg-light">配送先編集</h4>

--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -1,6 +1,15 @@
 <div class='container'>
 <div class='row pt-5'>
 <div class="col-sm-12 col-md-10 col-lg-10 px-5 px-sm-0 mx-auto">
+  
+<% if @shipping_address.errors.any? %>
+<%= @shipping_address.errors.count %>件のエラーが発生しました
+<ul>
+  <% @shipping_address.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+</ul>
+<% end %>
 
 <div class='pt-4'>
     <h4 class="bg-light">配送先登録/一覧</h4>

--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -3,13 +3,8 @@
 <div class="col-sm-12 col-md-10 col-lg-10 px-5 px-sm-0 mx-auto">
   
 <% if @shipping_address.errors.any? %>
-<%= @shipping_address.errors.count %>件のエラーが発生しました
-<ul>
-  <% @shipping_address.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</ul>
-<% end %>
+<%= render 'layouts/error_messages', model: @shipping_address %>
+<%end%>
 
 <div class='pt-4'>
     <h4 class="bg-light">配送先登録/一覧</h4>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,3 +4,49 @@
         pay_option:
           credit_card: "クレジットカード"
           transfer: "銀行振込"
+  
+    activerecord:
+      attributes:
+        admin:
+          email: メールアドレス
+          password: パスワード
+          
+        customer:
+          first_name: 姓
+          last_name: 名
+          first_name_kana: セイ
+          last_name_kana: メイ
+          post_code: 郵便番号
+          address: 住所
+          telephone_number: 電話番号
+          email: メールアドレス
+          password: パスワード
+          
+        shipping_address:
+          address_label: 宛名
+          post_code: 郵便番号
+          address: 住所
+          
+        genre:
+          name: ジャンル名
+          
+        item:
+          name: 商品名
+          introduction: 紹介文
+          price: 価格
+          image: 画像
+          
+        cart_item:
+          count: 数量
+          
+        order:
+          delivery_post_code: 郵便番号
+          delivery_address: 住所
+          delivery_address_label: 宛名
+          
+        order_item:
+          count: 個数
+      errors:
+        messages:
+          invalid: "%{attribute}が正しくありません。"
+    

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_18_054157) do
+ActiveRecord::Schema.define(version: 2023_04_20_100434) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -96,6 +96,15 @@ ActiveRecord::Schema.define(version: 2023_04_18_054157) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["customer_id"], name: "index_orders_on_customer_id"
+  end
+
+  create_table "postals", force: :cascade do |t|
+    t.integer "postal_code"
+    t.string "prefecture"
+    t.string "city"
+    t.string "town"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "shipping_addresses", force: :cascade do |t|


### PR DESCRIPTION
・全モデルにバリデーションを追加しました。自動で入力される値は飛ばしてます。
・新規登録、プロフィール編集、配送先編集画面にエラーメッセージを表示させています。  
→それ以外の画面ではバリデーションにかかるとエラーを吐く状態になってます

・部分テンプレート化したので、使う際は以下で呼び出してください。(時間があったら自分がやります！)
`<% if @○○.errors.any? %>`
`<%= render 'layouts/error_messages', model: @○○ %>`
`<%end%>`

・日本語化済みです。