### PR TITLE
[Fix] 遷移先の変更　ヘッダー表示変更

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -13,7 +13,7 @@ class Admin::ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to admin_items_path
+      redirect_to admin_item_path(@item)
     else
       @genres = Genre.all
       render :new

--- a/app/javascript/stylesheets/mystyle.css
+++ b/app/javascript/stylesheets/mystyle.css
@@ -1,3 +1,3 @@
 #thanks{
-  display: none
+  display: none;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,16 @@
 <header>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-ligth border-bottom border-danger p-4">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-ligth border-bottom border-danger">
     <div class="container">
-      <a class="navbar-brand text-dark" href="/"><span>Nagano Cake</span></a>
+      <%= link_to root_path do %>
+        <%= image_tag 'logo_transparent.png', size: '150x100' %>
+      <% end %>
+
       <div class="collapse navbar-collapse">
         <ul class="navbar-nav ml-auto">
           <% if customer_signed_in? %>
+            <li class="d-flex align-items-end mr-5">
+              ようこそ、<%= current_customer.first_name %>さん！
+            </li>
             <li>
               <%= link_to "About", about_path, class: 'c nav-link mr-2 rounded' %>
             </li>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -51,7 +51,7 @@
        
       <div class="d-flex bd-highlight">
         <div class="flex-grow-1 bd-highlight">
-          <%= link_to "買い物を続ける", items_path, class: 'btn btn-primary' %>
+          <%= link_to "買い物を続ける", root_path, class: 'btn btn-primary' %>
         </div>
         <div class="border border-bark bd-highlight bg-light p-3">
           合計金額


### PR DESCRIPTION
ヘッダーにロゴを追加しました。
会員側　　カート画面の買い物を続けるボタンの遷移先をTopページに変更
　　　　　ログインしている時にヘッダーに会員名（苗字）を表示するようにしました。
管理者側　新規商品登録後の遷移先を登録した商品の詳細ページへ変更