### PR TITLE
配送先がないとき一覧表を非表示

### DIFF
--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -41,7 +41,7 @@
 </div>
 
 <!--以下は一覧表-->
-
+<% unless @shipping_addresses.blank? %>
 <div class="px-3 pt-5 float-left">
 
   <table class="table table-bordered pl-5 ml-2">
@@ -67,6 +67,7 @@
 </table>
 
 </div>
+<%end%>
 
 </div>
 </div>


### PR DESCRIPTION
配送先一覧の見出しだけが小さく表示されているのを解消しました。