### PR TITLE
orders/confirmでリロードした際のエラーを解消

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ scope module: :public do
   resources :cart_items, only: [:index, :update, :destroy, :create] do
     delete 'destroy_all' => 'cart_items#destroy_all'
   end
+  get 'orders/confirm' => 'cart_items#index'
   post 'orders/confirm' => 'orders#confirm'
   get 'orders/completed' => 'orders#completed'
   resources :orders, only: [:new, :create, :index, :show]


### PR DESCRIPTION
get "orders/comfirm"に対応するルーティングを追加して、confirmで再読み込みした際にエラーを吐かないように設定しました。再読み込み後の遷移先はcart_items/indexにしてます。