### PR TITLE
［FIX］商品詳細　退会確認画面

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,7 +21,7 @@
               <%= link_to "商品一覧", items_path, class: 'c nav-link mr-2 rounded' %>
             </li>
             <li>
-              <%= link_to "カート", cart_items_path, class: 'c nav-link border mr-2 rounded' %>
+              <%= link_to "カート", cart_items_path, class: 'c nav-link mr-2 rounded' %>
             </li>
             <li>
               <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: 'c nav-link mr-2 rounded' %>

--- a/app/views/public/customers/withdraw.html.erb
+++ b/app/views/public/customers/withdraw.html.erb
@@ -1,6 +1,6 @@
 
 
-<div class="massages_and_buttons text-center pt-5 tr-color">
+<div class="massages_and_buttons text-center py-5">
   <h4 class="d-inline-block pt-5 pb-4">本当に退会しますか？</h4>
   <p class="pb-4">退会すると、会員登録情報や</br>
     これまでの購入履歴が閲覧できなくなります。<br>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,12 +1,12 @@
 <div class="container">
   <div class="row">
     <%= render 'list', genres: @genres %>
-    <div class="col-md-4 offset-md-1 d-flex align-items-center mt-5 tr-color">
+    <div class="col-md-4 offset-md-1 d-flex align-items-center mt-5 p-3 tr-color">
       <%= attachment_image_tag @item, :image,format: 'jpeg', size: "300x200", class: 'd-block mx-auto' %>
     </div>
-    <div class="col-md-4 d-flex align-items-center mt-5 tr-color">
+    <div class="col-md-4 d-flex align-items-center mt-5 p-4 tr-color">
       <div>
-        <h2 class="text-nowrap">
+        <h2 class="text-truncate">
           <%= @item.name %>
         </h2>
         <p>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -33,6 +33,8 @@
             <% if @item.sale_status.present? %>
               <%= f.select :count, *[1..100], {include_blank: '個数選択', selected: '個数選択'}, class: "form-control mr-3"%>
               <%= f.submit "カートに入れる", class: 'btn btn-outline-success' %>
+            <% else %>
+              <h5 class="text-danger"> 購入できません </h5>
             <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
商品詳細ページの商品名がはみ出すのを修正
商品詳細に「購入できません」追加
退会確認画面を修正