### PR TITLE
[Fix] 商品編集画面パス　値段表記統一

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -31,7 +31,7 @@ class Admin::ItemsController < ApplicationController
   def update
     @item = Item.find(params[:id])
     if @item.update(item_params)
-      redirect_to admin_items_path
+      redirect_to admin_item_path(@item)
     else
       render :edit
     end

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-12 col-md-10 col-lg-8 px-5 px-sm-0 mx-auto d-flex justify-content-between m-5">
-      <h5 class="bg-light d-flex align-items-center pr-3 pl-3">商品編集</h5>
+      <h5 class="d-flex align-items-center pr-3 pl-3">商品編集</h5>
     </div>
-    <div class="col-sm-12 col-md-8 col-lg-5 px-5 px-sm-0 mx-auto">
+    <div class="mx-auto tr-color p-3">
       
       <% if @item.errors.any? %>
         <%= render 'layouts/error_messages', model: @item %>
@@ -28,7 +28,7 @@
         </div>
         <div class="form-group form-inline">
           <%= f.label "税抜価格", class: 'w-25 justify-content-start' %>
-          <%= f.text_field :price, class: 'form-control w-25' %>円
+          <%= f.text_field :price, class: 'form-control w-25', size: 36 %>円
         </div>
         <div class="form-group form-inline">
           <%= f.label "販売ステータス", class: 'w-25 justify-content-start' %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -66,9 +66,9 @@
           <%= form_with model: order_item, url: admin_order_item_path(order_item.id) , method: :patch , local: true do |f| %>
             <tr>
               <td><%= order_item.item.name %></td>
-              <td><%= order_item.item.add_tax_sales_price %>円</td>
+              <td><%= order_item.item.add_tax_sales_price.to_s(:delimited) %>円</td>
               <td><%= order_item.count %></td>
-              <td><%= @subtotal %>円</td>
+              <td><%= @subtotal.to_s(:delimited) %>円</td>
               <td>
                 <%= f.select :work_status,OrderItem.work_statuses_i18n.invert,{class: "form-control"} %>
                 <%= f.submit "更新", class: "btn btn-sm btn-outline-success" %>
@@ -83,15 +83,15 @@
       <table class="table">
         <tr>
           <th class="table-active">商品合計</th>
-          <td class="tr-color"><%= @total %>円</td>
+          <td class="tr-color"><%= @total.to_s(:delimited) %>円</td>
         </tr>
         <tr>
           <th class="table-active">送料</th>
-          <td class="tr-color"><%= @order.shipping_fee %>円</td>
+          <td class="tr-color"><%= @order.shipping_fee.to_s(:delimited) %>円</td>
         </tr>
         <tr>
           <th class="table-active">請求金額合計</th>
-          <td class="tr-color"><%= @total + @order.shipping_fee %>円</td>
+          <td class="tr-color"><%= (@total + @order.shipping_fee).to_s(:delimited) %>円</td>
         </tr>
       </table>
     </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -41,16 +41,16 @@
           <tr>
             <th class="table-active">送料</th>
             <% @order.shipping_fee = 800 %>
-            <td class="tr-color"><%= @order.shipping_fee %>円</td>
+            <td class="tr-color"><%= @order.shipping_fee.to_s(:delimited) %>円</td>
           </tr>
           <tr>
             <th class="table-active">商品合計</th>
-            <td class="tr-color"><%= total.to_i %>円</td>
+            <td class="tr-color"><%= total.to_s(:delimited) %>円</td>
             </tr>
           <tr>
             <th class="table-active">請求金額</th>
             <% @order.total_price = @order.shipping_fee + total.to_i %>
-            <td class="tr-color"><%= @order.total_price %>円</td>
+            <td class="tr-color"><%= @order.total_price.to_s(:delimited) %>円</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
管理者側の商品編集画面で編集後のリンク先を商品詳細画面に直しました。
商品編集画面のレイアウト修正しました。